### PR TITLE
Secondary Fire Suport

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,7 +5,7 @@ const cmd = require('node-cmd');
 const fs = require('fs-extra');
 const cheerio = require('cheerio');
 
-const transformWeapon = require('./transformWeapon');
+const transformWeapon = require('./transformers/transformWeapon');
 
 let imageUrls;
 

--- a/transformers/transformWeapon.js
+++ b/transformers/transformWeapon.js
@@ -62,7 +62,7 @@ const transformWeapon = (oldWeapon, imageUrls) => {
       Trigger,
       ChargeAttack,
       SecondaryAttack,
-      SecondaryAreaAttack
+      SecondaryAreaAttack,
     } = oldWeapon;
   
     const { Name } = oldWeapon;
@@ -194,20 +194,20 @@ const transformWeapon = (oldWeapon, imageUrls) => {
     }
     
     if (SecondaryAttack) {
-       newWeapon.secondary = {
-          name: SecondaryAttack.AttackName,
-          speed: SecondaryAttack.FireRate,
-          crit_chance: SecondaryAttack.CritChance
-            && Number((Number(SecondaryAttack.CritChance) * 100).toFixed(2)),
-          crit_mult: SecondaryAttack.CritMultiplier
-            && Number(Number(SecondaryAttack.CritMultiplier).toFixed(1)),
-          status_chance: SecondaryAttack && SecondaryAttack.StatusChance
-            && Number(Number(SecondaryAttack.StatusChance).toFixed(1)),
-          charge_time: SecondaryAttack.ChargeTime
-            && Number(Number(SecondaryAttack.ChargeTime).toFixed(1)),
-          shot_type: SecondaryAttack.ShotType,
-          shot_speed: SecondaryAttack.ShotSpeed
-            && Number(Number(SecondaryAttack.ShotSpeed).toFixed(1))
+      newWeapon.secondary = {
+        name: SecondaryAttack.AttackName,
+        speed: SecondaryAttack.FireRate,
+        crit_chance: SecondaryAttack.CritChance
+          && Number((Number(SecondaryAttack.CritChance) * 100).toFixed(2)),
+        crit_mult: SecondaryAttack.CritMultiplier
+          && Number(Number(SecondaryAttack.CritMultiplier).toFixed(1)),
+        status_chance: SecondaryAttack && SecondaryAttack.StatusChance
+          && Number(Number(SecondaryAttack.StatusChance).toFixed(1)),
+        charge_time: SecondaryAttack.ChargeTime
+          && Number(Number(SecondaryAttack.ChargeTime).toFixed(1)),
+        shot_type: SecondaryAttack.ShotType,
+        shot_speed: SecondaryAttack.ShotSpeed
+          && Number(Number(SecondaryAttack.ShotSpeed).toFixed(1))
        };
        
        if (SecondaryAttack.PelletName) {
@@ -217,8 +217,8 @@ const transformWeapon = (oldWeapon, imageUrls) => {
         };
       }
        
-       // Convert damage numbers and names
-       if (SecondaryAttack.Damage) {
+      // Convert damage numbers and names
+      if (SecondaryAttack.Damage) {
         damageTypes.forEach((damageType) => {
           newWeapon.secondary[damageType.toLowerCase()] = SecondaryAttack.Damage[damageType] ? Number(SecondaryAttack.Damage[damageType].toFixed(2).replace(/(\.[\d]+)0/, '$1')) : undefined;
         });

--- a/transformers/transformWeapon.js
+++ b/transformers/transformWeapon.js
@@ -208,9 +208,9 @@ const transformWeapon = (oldWeapon, imageUrls) => {
         shot_type: SecondaryAttack.ShotType,
         shot_speed: SecondaryAttack.ShotSpeed
           && Number(Number(SecondaryAttack.ShotSpeed).toFixed(1))
-       };
+      };
        
-       if (SecondaryAttack.PelletName) {
+      if (SecondaryAttack.PelletName) {
         newWeapon.secondary.pellet = {
           name: SecondaryAttack.PelletName,
           count: SecondaryAttack.PelletCount,

--- a/transformers/transformWeapon.js
+++ b/transformers/transformWeapon.js
@@ -7,6 +7,11 @@ const ELEMENTS = {
   Heat: 'heat',
   Blast: 'blast',
   Radiation: 'radiation',
+  Cold: 'cold',
+  Viral: 'viral',
+  Magnetic: 'magnetic',
+  Gas: 'gas',
+  Void: 'void',
 };
 
 const POLARITIES = {
@@ -56,9 +61,15 @@ const transformWeapon = (oldWeapon, imageUrls) => {
       Image,
       Trigger,
       ChargeAttack,
+      SecondaryAttack,
+      SecondaryAreaAttack
     } = oldWeapon;
   
     const { Name } = oldWeapon;
+    
+    if (oldWeapon.Secondary) {
+      console.log(oldWeapon.Secondary);
+    }
 
     newWeapon = {
       regex: `^${Name.toLowerCase().replace(/\s/g, '\\s')}$`,
@@ -95,7 +106,7 @@ const transformWeapon = (oldWeapon, imageUrls) => {
       ...(NormalAttack && NormalAttack.FireRate)
         && { rate: Number(NormalAttack.FireRate.toFixed(1)) },
     };
-  
+
     if (NormalAttack) {
       newWeapon.damage = Object.keys(NormalAttack.Damage).reduce(
         (sum, damageType) => NormalAttack.Damage[damageType] + sum,
@@ -122,6 +133,17 @@ const transformWeapon = (oldWeapon, imageUrls) => {
       'Impact',
       'Slash',
       'Puncture',
+      'Heat',
+      'Cold',
+      'Electricity',
+      'Toxin',
+      'Viral',
+      'Corrosive',
+      'Radiation',
+      'Blast',
+      'Magnetic',
+      'Gas',
+      'Void',
     ];
     if (NormalAttack && NormalAttack.Damage) {
       damageTypes.forEach((damageType) => {
@@ -137,6 +159,77 @@ const transformWeapon = (oldWeapon, imageUrls) => {
         newWeapon[damageType.toLowerCase()] = ChargeAttack.Damage[damageType] ? Number(ChargeAttack.Damage[damageType].toFixed(2).replace(/(\.[\d]+)0/, '$1')) : undefined;
       });
     }
+    
+    if (SecondaryAreaAttack) {
+      newWeapon.secondaryArea = {
+        name: SecondaryAreaAttack.AttackName,
+        status_chance: SecondaryAreaAttack && SecondaryAreaAttack.StatusChance
+          && Number((Number(SecondaryAreaAttack.StatusChance) * 100).toFixed(2)),
+        duration: SecondaryAreaAttack && SecondaryAreaAttack.Duration
+          && Number((Number(SecondaryAreaAttack.Duration) * 100).toFixed(2)),
+        radius: SecondaryAreaAttack && SecondaryAreaAttack.Radius
+          && Number((Number(SecondaryAreaAttack.Radius) * 100).toFixed(2)),
+        speed: SecondaryAreaAttack && SecondaryAreaAttack.FireRate,
+      };
+      
+      if (SecondaryAreaAttack.PelletName) {
+        newWeapon.secondaryArea.pellet = {
+          name: SecondaryAreaAttack.PelletName,
+          count: SecondaryAreaAttack.PelletCount,
+        };
+      }
+      
+      
+      // Convert damage numbers and names
+      if (SecondaryAreaAttack.Damage) {
+        damageTypes.forEach((damageType) => {
+          newWeapon.secondaryArea[damageType.toLowerCase()] = SecondaryAreaAttack.Damage[damageType] ? Number(SecondaryAreaAttack.Damage[damageType].toFixed(2).replace(/(\.[\d]+)0/, '$1')) : undefined;
+        });
+        Object.keys(ELEMENTS).forEach((element) => {
+          if (SecondaryAreaAttack.Damage[element]) {
+            newWeapon.secondaryArea.damage = `${SecondaryAreaAttack.Damage[element].toFixed(2).replace(/(\.[\d]+)0/, '$1')} ${ELEMENTS[element]}`;
+          }
+        });
+      }
+    }
+    
+    if (SecondaryAttack) {
+       newWeapon.secondary = {
+          name: SecondaryAttack.AttackName,
+          speed: SecondaryAttack.FireRate,
+          crit_chance: SecondaryAttack.CritChance
+            && Number((Number(SecondaryAttack.CritChance) * 100).toFixed(2)),
+          crit_mult: SecondaryAttack.CritMultiplier
+            && Number(Number(SecondaryAttack.CritMultiplier).toFixed(1)),
+          status_chance: SecondaryAttack && SecondaryAttack.StatusChance
+            && Number(Number(SecondaryAttack.StatusChance).toFixed(1)),
+          charge_time: SecondaryAttack.ChargeTime
+            && Number(Number(SecondaryAttack.ChargeTime).toFixed(1)),
+          shot_type: SecondaryAttack.ShotType,
+          shot_speed: SecondaryAttack.ShotSpeed
+            && Number(Number(SecondaryAttack.ShotSpeed).toFixed(1))
+       };
+       
+       if (SecondaryAttack.PelletName) {
+        newWeapon.secondary.pellet = {
+          name: SecondaryAttack.PelletName,
+          count: SecondaryAttack.PelletCount,
+        };
+      }
+       
+       // Convert damage numbers and names
+       if (SecondaryAttack.Damage) {
+        damageTypes.forEach((damageType) => {
+          newWeapon.secondary[damageType.toLowerCase()] = SecondaryAttack.Damage[damageType] ? Number(SecondaryAttack.Damage[damageType].toFixed(2).replace(/(\.[\d]+)0/, '$1')) : undefined;
+        });
+        Object.keys(ELEMENTS).forEach((element) => {
+          if (SecondaryAttack.Damage[element]) {
+            newWeapon.secondary.damage = `${SecondaryAttack.Damage[element].toFixed(2).replace(/(\.[\d]+)0/, '$1')} ${ELEMENTS[element]}`;
+          }
+        });
+      }
+    }
+  
   
     if ((Type === 'Primary' || Type === 'Secondary') && NormalAttack) {
       newWeapon = {


### PR DESCRIPTION
### Wikia Scraper Pull Request
---

**Summary (short):** Secondary Fire (and secondary area) support

---
**Description:** Add transformations for secondary attacks

---
**Fixes issue (include link):** #6 

---
**Mockups, screenshots, evidence:**
```json
{
  "regex": "^angstrum$",
  "name": "Angstrum",
  "url": "http://warframe.wikia.com/wiki/Angstrum",
  "mr": 4,
  "type": "Secondary",
  "subtype": "Pistol",
  "riven_disposition": 5,
  "crit_chance": 16,
  "crit_mult": 2,
  "status_chance": 52.5,
  "polarities": ["vazarin"],
  "thumbnail": "https://vignette.wikia.nocookie.net/warframe/images/f/fe/CorpusHandRocket.png/revision/latest?cb=20170606150901",
  "ammo": 18,
  "accuracy": 26.7,
  "magazine": 3,
  "reload": 2.5,
  "projectile": "Projectile",
  "damage": 200,
  "trigger": "Charge (0.5s)",
  "blast": 200,
  "secondaryAreaAttack": {
    "name": "3-Rocket Barrage Impact",
    "status_chance": 52.5,
    "pellet": {
      "name": "Rocket",
      "count": 3
    },
    "blast": 600,
    "damage": "600.0 blast"
  },
  "secondaryAttack": {
    "name": "3-Rocket Barrage Explosion",
    "pellet": {
      "name": "Rocket",
      "count": 3
    },
    "blast": 750,
    "damage": "750.0 blast"
  }
}
```

---

(Check one)
- [x] Issue fix
- [x] Suggestion fulfillment
